### PR TITLE
agregar la opción de output para que lo tome github action

### DIFF
--- a/.github/workflows/secret.yml
+++ b/.github/workflows/secret.yml
@@ -28,10 +28,10 @@ jobs:
         #continue-on-error: true
         run: |
           curl -fsSL https://raw.githubusercontent.com/ZupIT/horusec/main/deployments/scripts/install.sh | bash -s latest
-          horusec start -p="./" --config-file-path horusec-config.json    
+          horusec start -p="./" --config-file-path horusec-config.json -o="json" -O="./report.json"
 
       - name: Upload  security scan result as artifact
         uses: actions/upload-artifact@v3
         with:
           name: horusec
-          path: horusec-config.json  
+          path: report.json  


### PR DESCRIPTION
El reporte no se llegaba a subir porque faltaban estas opciones: `-o="json" -O="./report.json"`

sin las opciones propuestas: [link](https://github.com/jaliagag/vulnerable-web-app/blob/c29672d0eadea8ae2a376bc195b7e47ffcd1bd70/.github/workflows/secret.yml#L31-L37)

![Screen Shot 2022-09-13 at 08 30 02](https://user-images.githubusercontent.com/40398975/189897718-7805add2-ab17-4dfb-b747-7c24c01fefd3.png)

con las opciones propuestas: [link](https://github.com/jaliagag/vulnerable-web-app/commit/6ca1151606b296dedfd760793ed03d04550c2e2e)

![Screen Shot 2022-09-13 at 09 10 32](https://user-images.githubusercontent.com/40398975/189897689-0ae8940c-0cbe-4720-935e-7a06eb5ff0d9.png)

